### PR TITLE
Reduce log to prevent disk to be full

### DIFF
--- a/clickhouse-posthog/Dockerfile
+++ b/clickhouse-posthog/Dockerfile
@@ -10,4 +10,7 @@ FROM clickhouse/clickhouse-server:22.3
 COPY --from=0 /posthog-1.40.0/posthog/idl/ /idl/
 COPY --from=0 /posthog-1.40.0/docker/clickhouse/docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 COPY --from=0 /posthog-1.40.0/docker/clickhouse/config.xml                 /etc/clickhouse-server/config.xml
-COPY --from=0 /posthog-1.40.0/docker/clickhouse/users.xml                  /etc/clickhouse-server/users.xml
+COPY --from=0 /posthog-1.40.0/docker/clickhouse/users.xml                  /etc/clickhouse-server/uselolog-g-serverl
+
+COPY ./log-server-config.xml                  /etc/clickhouse-server/config.d/
+COPY ./log-users-config.xml                  /etc/clickhouse-server/users.d/

--- a/clickhouse-posthog/log-server-config.xml
+++ b/clickhouse-posthog/log-server-config.xml
@@ -1,0 +1,16 @@
+<yandex>
+    <logger>
+        <level>warning</level>
+        <console>true</console>
+    </logger>
+    <query_thread_log remove="remove"/>
+    <query_log remove="remove"/>
+    <text_log remove="remove"/>
+    <trace_log remove="remove"/>
+    <metric_log remove="remove"/>
+    <asynchronous_metric_log remove="remove"/>
+
+    <!-- Update: Required for newer versions of Clickhouse -->
+    <session_log remove="remove"/>
+    <part_log remove="remove"/>
+</yandex>

--- a/clickhouse-posthog/log-users-config.xml
+++ b/clickhouse-posthog/log-users-config.xml
@@ -1,0 +1,8 @@
+<yandex>
+    <profiles>
+        <default>
+            <log_queries>0</log_queries>
+            <log_query_threads>0</log_query_threads>
+        </default>
+    </profiles>
+</yandex>


### PR DESCRIPTION
Following this article https://theorangeone.net/posts/calming-down-clickhouse/ I reduce log with in clickhouse configuration